### PR TITLE
ci(cf): add Cloudflare deploy workflow (auto-deploy on main)

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -1,0 +1,77 @@
+name: Deploy Cloudflare Workers
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'packages/remote-mcp-server-authless/**'
+      - 'packages/cloudflare-canvas-api/**'
+      - '.github/workflows/cf-deploy.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: cf-deploy-prod
+  cancel-in-progress: true
+
+jobs:
+  deploy-mcp-sse:
+    name: Deploy MCP SSE Worker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            packages/remote-mcp-server-authless/package-lock.json
+
+      - name: Install deps (mcp-sse)
+        working-directory: packages/remote-mcp-server-authless
+        run: npm ci
+
+      - name: Deploy mcp-sse
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/remote-mcp-server-authless
+          command: deploy
+
+  deploy-api:
+    name: Deploy Canvas API Proxy (optional)
+    needs: deploy-mcp-sse
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            packages/cloudflare-canvas-api/package-lock.json
+
+      - name: Install deps (api)
+        working-directory: packages/cloudflare-canvas-api
+        run: |
+          if [ -f package.json ]; then npm ci; else echo "No api package.json; skipping"; fi
+
+      - name: Deploy api
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/cloudflare-canvas-api
+          command: deploy
+        continue-on-error: true
+

--- a/docs/CLOUDFLARE_DEPLOY.md
+++ b/docs/CLOUDFLARE_DEPLOY.md
@@ -1,0 +1,35 @@
+# Cloudflare Auto‑Deploy (GitHub Actions)
+
+This repo deploys the Workers on every push to `main` using GitHub Actions.
+
+## Secrets to Add (Repository → Settings → Secrets and variables → Actions)
+
+- `CLOUDFLARE_ACCOUNT_ID` – Your Cloudflare Account ID
+- `CLOUDFLARE_API_TOKEN` – API token with `Workers Scripts:Edit`, `Workers KV:Edit` (if used), and `Pages:Edit` if needed
+
+## Workflow
+
+- `.github/workflows/cf-deploy.yml`
+- Deploys:
+  - `packages/remote-mcp-server-authless` (MCP SSE server)
+  - `packages/cloudflare-canvas-api` (optional proxy, best effort)
+
+## Local Manual Deploy (optional)
+
+```bash
+cd packages/remote-mcp-server-authless
+npm ci
+npx wrangler whoami
+npx wrangler deploy
+```
+
+## Verify
+
+```bash
+curl -s https://canvas-mcp-sse.ariff.dev/.well-known/mcp-config | jq
+curl -s https://canvas-mcp-sse.ariff.dev/.well-known/oauth-authorization-server | jq
+curl -i -X OPTIONS https://canvas-mcp-sse.ariff.dev/sse -H 'Origin: https://smithery.ai' -H 'Access-Control-Request-Method: GET'
+```
+
+If you need help generating the API token, open Cloudflare dashboard → My Profile → API Tokens → Create → “Edit Cloudflare Workers”.
+


### PR DESCRIPTION
Adds CF deploy workflow using cloudflare/wrangler-action@v3. Requires repo secrets CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID. Includes docs in docs/CLOUDFLARE_DEPLOY.md.